### PR TITLE
Update README.md for LetsencryptGlesysHook

### DIFF
--- a/BASH/LetsencryptGlesysHook/README.md
+++ b/BASH/LetsencryptGlesysHook/README.md
@@ -1,3 +1,5 @@
 # letsencrypt-glesys-hook
 
-For use with [letsencrypt.sh](https://github.com/lukas2511/letsencrypt.sh) which has support for LetsEncrypt DNS-01 Challenge.
+For use with [dehydrated](https://github.com/lukas2511/dehydrated) which has support for LetsEncrypt DNS-01 Challenge.
+
+You can also use [lexicons hook for dehydrated](https://github.com/AnalogJ/lexicon/blob/master/examples/dehydrated.default.sh). Lexicon supports GleSYS DNS.


### PR DESCRIPTION
* Letsencrypt.sh changed name to dehydrated.
* Add tip about using lexicons hook for dehydrated.