### PR TITLE
Remove the beta label from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-***The GleSYS API is currently in BETA-state***
-
 # What is this?
 This is the place to go for [documentation](https://github.com/GleSYS/API/wiki), [examples](https://github.com/GleSYS/API/) and [support/feedback](https://github.com/GleSYS/API/issues) for [GleSYS](http://www.glesys.se) API.
 


### PR DESCRIPTION
The GleSYS API (located at https://api.glesys.com/) has been available and used in production for several years now. We rarely do any breaking changes and the few times we do, we go great lengths to make sure it does not affect any customer.

This PR removes the beta label from readme to further show that we consider our API stable.